### PR TITLE
Adding logic to check for boundary case in capitalization warning

### DIFF
--- a/src/js/survis.js
+++ b/src/js/survis.js
@@ -168,7 +168,7 @@ var warnings = (function () {
     }
 
     function computeWholeFieldCapitalizationProtected(warningsList, field, value) {
-        if (value.indexOf('{') == 0 && value.lastIndexOf('}') == value.length - 1 && value.length > 10 && (value.split("{").length - 1 == 1) )  {
+        if (value.indexOf('{') === 0 && value.lastIndexOf('}') === value.length - 1 && value.length > 10 && (value.split("{").length - 1 === 1) )  {
             warningsList.push('whole field "' + field + '" with protected capitalization');
         }
     }

--- a/src/js/survis.js
+++ b/src/js/survis.js
@@ -168,7 +168,7 @@ var warnings = (function () {
     }
 
     function computeWholeFieldCapitalizationProtected(warningsList, field, value) {
-        if (value.indexOf('{') == 0 && value.lastIndexOf('}') == value.length - 1 && value.length > 10) {
+        if (value.indexOf('{') == 0 && value.lastIndexOf('}') == value.length - 1 && value.length > 10 && (value.split("{").length - 1 == 1) )  {
             warningsList.push('whole field "' + field + '" with protected capitalization');
         }
     }


### PR DESCRIPTION
I have added the logic to check the boundary case in capitalization warning.
The old case checked for first and last occurrence of curly braces only. Now it only checks whether '{' appears only once at beginning of the field and '}' at the end of field, then the entire field is capitalized.

I was not sure why the field's length should be greater than 10 characters to check for whole field capitalization (value.length > 10).