### PR TITLE
skips BibTeX comments.

### DIFF
--- a/update_data.py
+++ b/update_data.py
@@ -24,6 +24,8 @@ def parseBibtex(bibFile):
         currentId = ""
         for line in fIn:
             line = line.strip("\n").strip("\r")
+            if line.startswith("@Comment"):
+                continue
             if line.startswith("@"):
                 currentId = line.split("{")[1].rstrip(",\n")
                 currentType = line.split("{")[0].strip("@ ")


### PR DESCRIPTION
Reference Managers like JabRef add comments to the BibTeX file, e.g.: `% Encoding: UTF-8` or `@Comment{jabref-meta: databaseType:bibtex;}`. Our python updater ignores the first one, but creates an entry for the second one in the generated Javascript file.

This pull request fixes the creation of entries from comments for lines starting with `@Comment`.